### PR TITLE
Add support for devcontainers w/o dart debugging

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go/.devcontainer/base.Dockerfile
+ARG VARIANT="1"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Optional] Install a version of Node.js using nvm for front end dev
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment the next line to use go get to install anything else you need
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+RUN apt-get update 
+RUN apt-get install -y curl git wget unzip libgconf-2-4 gdb libstdc++6 libglu1-mesa fonts-droid-fallback lib32stdc++6 python3
+RUN apt-get clean
+RUN mkdir /usr/local/flutter
+RUN chown vscode:vscode /usr/local/flutter 
+
+USER vscode
+
+RUN git clone https://github.com/flutter/flutter.git /usr/local/flutter
+
+ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
+
+RUN flutter doctor -v
+RUN flutter channel master
+RUN flutter upgrade
+RUN flutter config --enable-web

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.15, 1.14
+			"VARIANT": "1",
+			// Options
+			"INSTALL_NODE": "false",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.gopath": "/go",
+		"go.useLanguageServer": true
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go",
+		"dart-code.flutter",
+		"dart-code.dart-code",
+		"coenraads.bracket-pair-colorizer-2",
+		"jeroen-meijer.pubspec-assist"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Go Backend",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/backend/server.go"
+        },
+        {
+            "name": "Launch Flutter Frontend",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release",
+            "program": "${workspaceFolder}/frontend/lib/main.dart",
+            "flutterDisableVmServiceExperimental": true,
+			"args": [
+				"--web-hostname",
+				"any",
+                "--dart-define=DASHI_API_BASE_URL=localhost:8443"
+			],
+            "env": {
+                "DASHI_API_BASE_URL": "localhost:8443"
+            }
+        }
+    ]
+}

--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -8,9 +8,14 @@ class APIService {
   static final APIService instance = APIService._instantiate();
 
   // final String _baseUrl = '192.168.68.91:8443';
-  final String _baseUrl = '';
+  String _baseUrl = '';
 
   Future<List<Apps>> fetchApps() async {
+    const dashiBaseUrl = String.fromEnvironment('DASHI_API_BASE_URL');
+    print("Dashi API Base URL being set to: ");
+    print(dashiBaseUrl);
+    _baseUrl = dashiBaseUrl;
+
     Uri uri = Uri.http(_baseUrl, '/api/apps');
     Map<String, String> headers = {
       HttpHeaders.contentTypeHeader: 'application/json',

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -16,7 +16,7 @@ RUN flutter config --enable-web
 RUN mkdir /app
 COPY frontend /app
 WORKDIR /app
-RUN flutter build web
+RUN flutter build web --dart-define=DASHI_API_BASE_URL=localhost:8443
 
 FROM golang:1.13.1-alpine AS GO_BUILD
 RUN apk add build-base


### PR DESCRIPTION
Add support for opening the project in a ready-made docker container within vs code (and soon github workspaces). Dart debugging is not yet working, but the frontend can be started with the standard debugging start command of VSCode.